### PR TITLE
AuthService 리팩토링

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,3 @@
+const NEXT_PUBLIC_API_HOST = process.env.NEXT_PUBLIC_API_HOST;
+
+export { NEXT_PUBLIC_API_HOST };

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1,0 +1,28 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { NEXT_PUBLIC_API_HOST } from '../constants';
+
+
+class ApiService {
+  async get(url: string, config?: AxiosRequestConfig<any> | undefined) {
+    const response = await axios.get(
+      NEXT_PUBLIC_API_HOST + url,
+      config
+    );
+    return response;
+  }
+
+  async post(
+    url: string,
+    data?: { [key: string]: any } | null | undefined,
+    config?: AxiosRequestConfig<null> | undefined
+  ) {
+    const response = await axios.post(
+      NEXT_PUBLIC_API_HOST + url,
+      data,
+      config
+    );
+    return response;
+  }
+}
+
+export default ApiService;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import cookies from "js-cookie";
 import ApiService from "./api.service";
 
@@ -59,7 +58,7 @@ class AuthService extends ApiService {
 
   /** 이미 생성된 계정의 토큰을 발급받습니다. */
   async login(email: string, password: string) {
-    const { data } = await axios.post(
+    const { data } = await this.post(
       process.env.NEXT_PUBLIC_API_HOST + "/auth/login",
       { email, password }
     );

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,15 +1,14 @@
-import axios from "axios";
 import cookies from "js-cookie";
+import ApiService from "./api.service";
 
-class UserService {
+class UserService extends ApiService {
   async me() {
     const accessToken = cookies.get("accessToken");
     if (!accessToken) {
       return;
     }
 
-    const { data } = await axios.get(
-      process.env.NEXT_PUBLIC_API_HOST + "/users/me",
+    const { data } = await this.get("/users/me",
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -21,9 +20,7 @@ class UserService {
   }
 
   async read(id: number) {
-    const { data } = await axios.get(
-      process.env.NEXT_PUBLIC_API_HOST + "/users/" + id
-    );
+    const { data } = await this.get(`/users/${id}`);
 
     return data;
   }


### PR DESCRIPTION
## 주요내용
1. ApiService 생성, userService, authService에서 상속
-> 두개의 Service에서 공통된 기능을 apiService 클래스로 분리
2. ApiService의 메소드는 외부에서 의존성 주입이 가능하게 최대한 고려
-> 주요 Config, url등 외부에서 주입 가능 (좀 더 학습 필요)
3. Constants 폴더 추가 
-> 바뀌지 않을 상수들 해당 폴더에  추가
4. AuthService 클래스에서 setAccessToken, setRefreshToken 추가
-> 처음에는 하나의 메소드로 고려하였으나 두개의 토큰으로 분리, 타입으로 분기를 나누어 처리하는 것은 두개의 기능을 수행한다 생각하여 메소드 분리, config는 외부에서 주입 할 수 있게 세팅


## 참고자료
https://www.youtube.com/watch?v=aSAGOH2u2rs
https://velog.io/@roo333/SOLID-%EC%9D%98%EC%A1%B4-%EC%97%AD%EC%A0%84-%EC%9B%90%EC%B9%99DIP
https://thoughtful-arch-8c2.notion.site/2e386a766d1348fc8a2774055b310386

<img width="536" alt="image" src="https://user-images.githubusercontent.com/50283326/175527193-8d380f4c-b941-4c65-98c7-b7881e9db885.png">
<img width="352" alt="image" src="https://user-images.githubusercontent.com/50283326/175527208-03548c43-2c5c-4329-9285-1a1e1f413279.png">
